### PR TITLE
🚚 Null 처리 관련 확장함수 common 모듈로 이동

### DIFF
--- a/app/src/main/java/gyul/songgyubin/daytogo/location/model/mapper/LocationUiModelMapper.kt
+++ b/app/src/main/java/gyul/songgyubin/daytogo/location/model/mapper/LocationUiModelMapper.kt
@@ -1,7 +1,7 @@
 package gyul.songgyubin.daytogo.location.model.mapper
 
 import gyul.songgyubin.daytogo.location.model.LocationUiModel
-import gyul.songgyubin.daytogo.utils.extensions.orDefault
+import com.gyub.common.util.extensions.orDefault
 import gyul.songgyubin.domain.location.model.LocationEntity
 
 /**

--- a/common/src/main/java/com/gyub/common/util/extensions/BooleanExtension.kt
+++ b/common/src/main/java/com/gyub/common/util/extensions/BooleanExtension.kt
@@ -1,4 +1,4 @@
-package gyul.songgyubin.daytogo.utils.extensions
+package com.gyub.common.util.extensions
 
 /**
  * Boolean 형 확장함수

--- a/common/src/main/java/com/gyub/common/util/extensions/DoubleExtension.kt
+++ b/common/src/main/java/com/gyub/common/util/extensions/DoubleExtension.kt
@@ -1,4 +1,4 @@
-package gyul.songgyubin.daytogo.utils.extensions
+package com.gyub.common.util.extensions
 
 /**
  * Double형 Extension

--- a/common/src/main/java/com/gyub/common/util/extensions/IntExtension.kt
+++ b/common/src/main/java/com/gyub/common/util/extensions/IntExtension.kt
@@ -1,4 +1,4 @@
-package gyul.songgyubin.daytogo.utils.extensions
+package com.gyub.common.util.extensions
 
 /**
  * Int형 확장함수


### PR DESCRIPTION
## 작업 내용 📇
- Null 처리 관련 확장함수 `common` 모듈로 이동
## 상세 내용 ⌨️
- null 처리 관련 확장함수를 확장성있게 `common` 모듈로 이동
  - 기존에 `presentation` 모듈에 존재했지만 `domain, data layer`에서 사용이 불가하여 범용성이 떨어짐
  - 모든 레이어에서 의존할 수 있는 `common` 모듈에 추가
  - 주의할 점은 `domain layer`도 `common` 모듈에 의존하고 있기 때문에 되도록이면 순수 자바/코틀린으로 구성 필요
  - 그 외 로그 등 플랫폼에 의존적인 기능이 필요하다면 새로운 모듈을 만들거나 의존성 역전 원칙을 도입하여 해결 필요